### PR TITLE
Make Utils platform independent

### DIFF
--- a/src/main/java/org/qzhu/mutationObserver/Utils.java
+++ b/src/main/java/org/qzhu/mutationObserver/Utils.java
@@ -36,7 +36,7 @@ public class Utils {
                     getAllFilesFromDir(fileNames, suffix ,String.valueOf(path));
                 } else {
                     if(path.toAbsolutePath().toString().endsWith(suffix)) {
-                        fileNames.add(path.toString());
+                        fileNames.add(path.toString().replaceAll("\\\\", "/"));
                     }
                 }
             }

--- a/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
+++ b/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
@@ -28,9 +28,9 @@ public class UtilsTest {
         List<String> fileNames = new ArrayList<>();
         fileNames = getAllFilesFromDir(fileNames,".java",testDir);
         assertEquals(3,fileNames.size());
-        assertEquals("./src/main/resources/ClassPathUtils.java", fileNames.get(0));
-        assertEquals("./src/main/resources/helloworld.java", fileNames.get(1));
-        assertEquals("./src/main/resources/TypeUtils.java", fileNames.get(2));
+        assertTrue(fileNames.contains("./src/main/resources/ClassPathUtils.java"));
+        assertTrue(fileNames.contains("./src/main/resources/helloworld.java"));
+        assertTrue(fileNames.contains("./src/main/resources/TypeUtils.java"));
     }
 
 

--- a/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
+++ b/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
@@ -1,8 +1,10 @@
 package org.qzhu.mutationObserver;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.qzhu.mutationObserver.source.MethodInfo;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -14,15 +16,21 @@ import static org.qzhu.mutationObserver.Utils.*;
  */
 public class UtilsTest {
 
+	@BeforeClass
+	public static void setup() {
+		// Create a results folder if not already exists.
+		new File("./src/main/results/").mkdirs();
+	}
+	
     @Test
     public void testGetAllFilesFromDir() throws IOException {
-
         String testDir ="./src/main/resources/";
         List<String> fileNames = new ArrayList<>();
         fileNames = getAllFilesFromDir(fileNames,".java",testDir);
         assertEquals(3,fileNames.size());
-        assertTrue(fileNames.contains("./src/main/resources/helloworld.java"));
-        assertTrue(fileNames.contains("./src/main/resources/ClassPathUtils.java"));
+        assertEquals("./src/main/resources/ClassPathUtils.java", fileNames.get(0));
+        assertEquals("./src/main/resources/helloworld.java", fileNames.get(1));
+        assertEquals("./src/main/resources/TypeUtils.java", fileNames.get(2));
     }
 
 

--- a/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
+++ b/src/test/java/org/qzhu/mutationObserver/UtilsTest.java
@@ -28,8 +28,8 @@ public class UtilsTest {
         List<String> fileNames = new ArrayList<>();
         fileNames = getAllFilesFromDir(fileNames,".java",testDir);
         assertEquals(3,fileNames.size());
-        assertTrue(fileNames.contains("./src/main/resources/ClassPathUtils.java"));
         assertTrue(fileNames.contains("./src/main/resources/helloworld.java"));
+        assertTrue(fileNames.contains("./src/main/resources/ClassPathUtils.java"));
         assertTrue(fileNames.contains("./src/main/resources/TypeUtils.java"));
     }
 


### PR DESCRIPTION
The paths generated with Utils received backslashes instead of slashes on Windows systems. By replacing the backslashes, the program is now platform independent.

An extra assertion was added to the test for the filenames in a directory.

Also, `/results` was a missing directory for systems who've never run the program before. This folder is now created before class on JUnit run.

Tests (and build) pass on Windows and Ubuntu.