### PR TITLE
Add Gradle build directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This will produce a `target` directory with the following two jars:
 - mutationObserver-1.0-SNAPSHOT-jar-with-dependencies.jar: This is an executable jar which includes the mutation mutation observer
 
 ## Run
-The current version of `mutation_observer` can only work with maven project. Before running `mutation_observer`, you need to compile and test the target project (`mvn test`) and obtain the [PiTest](http://pitest.org/quickstart/maven/) mutation result for your project. The PiTest mutation result must in `csv` format. You can achieve that with `outputFormats` in Pitest plugin:
+The current version of `mutation_observer` works on the assumption that the observed project is built using either Maven or Gradle (i.e. it expects the build directory of either build tool). Before running `mutation_observer`, you need to compile and test the target project (`mvn test`) and obtain the [PiTest](http://pitest.org/quickstart/maven/) mutation result for your project. The PiTest mutation result must in `csv` format. You can achieve that with `outputFormats` in Pitest plugin:
 ```xml
 <plugin>
      <groupId>org.pitest</groupId>

--- a/src/main/java/org/qzhu/mutationObserver/Main.java
+++ b/src/main/java/org/qzhu/mutationObserver/Main.java
@@ -1,6 +1,9 @@
 package org.qzhu.mutationObserver;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,7 +46,7 @@ class Main {
            analyse(project,baseDir,pitestFileName,resultFileName);
            returnValue =  0;
        } catch (IOException e) {
-           System.err.println("No Such File Exception");
+           System.err.println(e.getMessage());
            returnValue = -2;
        } catch(IndexOutOfBoundsException e){
            System.err.println("Index Out Of Bounds Exception");
@@ -59,8 +62,26 @@ class Main {
 
        //String baseDir = "/Users/qianqianzhu/phd/testability/ast/project/";
        String testDir = baseDir+project+"/src/main/java/";
-       String sourceClassDir = baseDir+project+"/target/classes/";
-       String testClassDir = baseDir+project+"/target/test-classes/";
+
+       // Use either Maven or Gradle build directory.
+       String mavenBuildDir = baseDir+project+"/target/";
+       String gradleBuildDir = baseDir+project+"/build/classes/java/";
+       String sourceClassDir, testClassDir;
+       // Check whether the Maven build directory (target) exists.
+       // If this is the case, use Mavens source and test class directory
+       if (Files.exists(FileSystems.getDefault().getPath(mavenBuildDir))) {
+           sourceClassDir = mavenBuildDir+"/classes/";
+           testClassDir = mavenBuildDir+"/test-classes/";
+       }
+       // If this is not the case, use Gradles source and test class directory
+       else if (Files.exists(FileSystems.getDefault().getPath(gradleBuildDir))) {
+           sourceClassDir = gradleBuildDir+"/main/";
+           testClassDir = gradleBuildDir+"/test/";
+       }
+       // If neither exist, throw exception for not finding either standard build directory
+       else {
+           throw new FileNotFoundException("The standard Maven or Gradle build directory is not found.");
+       }
 
        List<String> fileNames = new ArrayList<>();
        fileNames = Utils.getAllFilesFromDir(fileNames,".java",testDir);


### PR DESCRIPTION
In this commit, support for the Gradle build directory is added. This
means that, instead of assuming the Maven ('target') build directory, it
is checked whether this exists. If it does not, instead, the Gradle
('build') build directory is assumed, and set if it exists. If neither
exists, then a FileNotFoundException is thrown.